### PR TITLE
Fix AWS region error

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -17,7 +17,7 @@ module.exports = CoreObject.extend({
     var client            = this._client;
     var stackId           = options.stackId;
     var appId             = options.appId;
-    var region            = options.region;
+    // var region            = options.region;
     var comment           = options.comment;
     var createDeployment  = RSVP.denodeify(client.createDeployment.bind(client));
 
@@ -28,7 +28,6 @@ module.exports = CoreObject.extend({
       StackId: stackId, /* required */
       AppId: appId,
       Comment: comment || '',
-      region: region
     };
 
     plugin.log('triggering OpsWorks deployment');


### PR DESCRIPTION
Previously, #7 made a small change to fix a linting issue. However, it
broken the AWS region setting. This commit reverts that change.

Ideally, the region option could be configured but, for now, this simply reverts to the pre-1.0.0 behaviour.